### PR TITLE
Fix TypeScript build error: Add vitest/globals types to tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["vitest/globals"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Resolves "Cannot find name 'beforeEach'" error in CI/CD workflow.

Changes:
- Added "types": ["vitest/globals"] to frontend tsconfig.json
- Enables TypeScript to recognize global vitest test functions
- Build now passes successfully

The vite.config.ts already had `test: { globals: true }` but TypeScript wasn't aware of the global types. This adds the necessary type declarations.

Fixes GitHub Actions workflow failure in PR #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)